### PR TITLE
Enables file uploads within repeatable fields

### DIFF
--- a/app/Http/Controllers/Admin/EffectCrudController.php
+++ b/app/Http/Controllers/Admin/EffectCrudController.php
@@ -40,7 +40,7 @@ class EffectCrudController extends CrudController
 
     /**
      * Configure the CrudPanel object. Apply settings to all operations.
-     * 
+     *
      * @return void
      */
     public function setup()
@@ -52,31 +52,32 @@ class EffectCrudController extends CrudController
 
     /**
      * Define what happens when the List operation is loaded.
-     * 
+     *
      * @see  https://backpackforlaravel.com/docs/crud-operation-list-entries
      * @return void
      */
     protected function setupListOperation()
     {
-        $this->crud->addFilter([ 
-            'type'  => 'simple',
-            'name'  => 'team_id',
-            'label' => 'Team'
-          ],
-          false,
-          function() { 
-            $teams = backpack_user()->teams;
-            
-            $this->crud->addClause('whereIn', 'team_id', $teams); 
-       
-        });
+        $this->crud->addFilter(
+            [
+                'type'  => 'simple',
+                'name'  => 'team_id',
+                'label' => 'Team'
+            ],
+            false,
+            function () {
+              $teams = backpack_user()->teams;
+
+              $this->crud->addClause('whereIn', 'team_id', $teams);
+          }
+        );
 
         $this->crud->addColumns([
             [
                 'label'     => "Team",
                 'type'      => 'select',
                 'name'      => 'team_id',
-                'entity'    => 'team', 
+                'entity'    => 'team',
                 'model'     => "App\Models\Team",
                 'attribute' => 'name',
 
@@ -93,7 +94,7 @@ class EffectCrudController extends CrudController
 
     /**
      * Define what happens when the Create operation is loaded.
-     * 
+     *
      * @see https://backpackforlaravel.com/docs/crud-operation-create
      * @return void
      */
@@ -101,20 +102,20 @@ class EffectCrudController extends CrudController
     {
         CRUD::setValidation(EffectRequest::class);
 
-        CRUD::addFields([ 
+        CRUD::addFields([
             [  // Select
                 'label'     => "Team",
                 'type'      => 'select',
-                'name'      => 'team_id', 
-                'entity'    => 'team', 
-                'model'     => "App\Models\Team", 
-                'attribute' => 'name', 
+                'name'      => 'team_id',
+                'entity'    => 'team',
+                'model'     => "App\Models\Team",
+                'attribute' => 'name',
                 // optional - force the related options to be a custom query, instead of all();
                 'options'   => (function ($query) {
                     $teams =  backpack_user()->teams()->pluck('teams.id')->toArray();
-                   
+
                     return $query->whereIn('id', $teams)->get();
-                 }), 
+                }),
             ],
             [
                 'name'          => 'description',
@@ -127,13 +128,13 @@ class EffectCrudController extends CrudController
                 'label' => '<p>This section collects information about indicators that measure the effect you have described.</p>
 
                 <p>If you are using one of the commonly used indicators provided, please select it. If you are using a different indicator, please describe it.</p>
-                
+
                 <p>You have freedom to use what you consider are the best indicators that provide the required evidence.</p>
-                
+
                 <p>If there is more than one indicator, please click on the "+ Add Indicator" sign to add space for a new indicator. You can enter as many as you need.</p>',
                 'type'  => 'repeatable',
                 'fields' => [
-                
+
                     [
                         'name'  => 'indicator_label',
                         'type'  => 'custom_html',
@@ -145,10 +146,10 @@ class EffectCrudController extends CrudController
                     //     'name'    => 'indicator_id',
                     //     'type' => "select_from_array",
                     //     'label' => 'Indicator ',
-                      
+
                     //     // optional - force the related options to be a custom query, instead of all();
-                    //     'options'   => $this->getIndicators(),     
-                      
+                    //     'options'   => $this->getIndicators(),
+
                     // ],
                     [
                         'name' => 'ind_value_id',
@@ -170,14 +171,14 @@ class EffectCrudController extends CrudController
                         'name'    => 'value_qualitative',
                         'type'    => 'text',
                         'label'   => 'I.2 If the indicator you have chosen is qualitative, please describe that changes captures the size of effect you are reporting. This is how the indicator “changed” from its original condition',
-                     
+
                     ],
                     [
                         'name'    => 'baseline_qualitative',
                         'type'   =>'text',
                         'label' => 'I.2.1 If you have a baseline for this qualitative indicator, what was its status at baseline?<p></p>',
 
-                     
+
                     ],
                     [   // CustomHTML
                         'name'  => 'separator',
@@ -188,16 +189,16 @@ class EffectCrudController extends CrudController
                         'name'    => 'value_quantitative',
                         'type'    => 'number',
                         'label'   => 'I.3 If the indicator you have chosen is quantitative, please indicate the size of the effect in numbers in the box below. This is how much has the indicator “changed” from its original value',
-                        
+
 
                     ],
-                  
+
                     [
                         'name'    => 'baseline_quantitative',
                         'type'   =>'number',
                         'label' => 'I.3.1 If you have a baseline for this indicator, what was its value at baseline? What is the value of the indicator now?',
-                       
-                       
+
+
                     ],
                     [
                         'name' => 'effect_indicator_id',
@@ -210,60 +211,60 @@ class EffectCrudController extends CrudController
                         'type'    => 'text',
                         'label'   => 'I.4 What was the source for this estimate of the indicator?
                         <p>I.4.1 Please provide a source that can be referenced. If it is on-line, please provide a URL.</p>',
-                       
+
                     ],
                     [   // Upload
                         'name'      => 'file_source',
                         'label'     => 'I.4.2 If you have a document that supports this indicator us evidence, you can upload it here.',
                         'type'      => 'upload',
                         'upload'    => true,
-                        'disk'      => 'public', 
+                        'disk'      => 'public',
                     ],
                     [
                         'name'    => 'level_attribution_id',
                         'type' => "select_from_array",
                         'label' => 'I.5 What is the level of attribution to the change in the indicator due to the work described?',
-                      
+
                         // optional - force the related options to be a custom query, instead of all();
-                        'options'   => $this->getLevelAttributions(),     
-                       
-                      
+                        'options'   => $this->getLevelAttributions(),
+
+
                     ],
                     // [
                     //     'name'    => 'indicator_status_id',
                     //     'label' => 'Indicator Status',
-                     
+
                     //     // optional - force the related options to be a custom query, instead of all();
                     //     'options'   =>  $this->getIndicatorStatus(),
                     // ],
-                   
-                    
+
+
                     [
                         'name'    => 'disaggregation_id',
                         'type' => "select2_from_array",
                         'label' => 'I.6 If you can disaggregate this indicator, please indicate the criteria it can be disaggregated by',
-                      
+
                         // optional - force the related options to be a custom query, instead of all();
-                        'options'   => $this->getDisaggregations(),   
+                        'options'   => $this->getDisaggregations(),
                         'allows_multiple' => true,
                         'allows_null' => true,
-                          
+
                     ]
-                   
-                    
+
+
                 ],
-            
+
                 // optional
                 'new_item_label'  => 'Add Indicator', // customize the text of the button
-                
+
             ],
             [   // CustomHTML
                 'name'  => 'separator',
                 'type'  => 'custom_html',
                 'value' => '<h6><b>Evidence</b></h6><p> Here you will enter any links (URLs) to supporting documents/sites for the evidence you have provided. If you need to add more than one link, press the "+" sign.</p>'
             ],
-            
-            
+
+
             [   // repeatable evidencies
                 'name'  => 'evidences_repeat',
                 'label' => '',
@@ -279,14 +280,14 @@ class EffectCrudController extends CrudController
                     [
                         'name'    => 'description',
                         'type'    => 'text',
-                        'label'   => 'E.1 Evidence desciption',                       
-                    ],  
+                        'label'   => 'E.1 Evidence desciption',
+                    ],
                     [
                         'name'    => 'files_description',
                         'type'    => 'text',
                         'label'   => 'E.2 file desciption',
-                       
-                    ],    
+
+                    ],
                     [   // Upload
                         'name'      => 'files',
                         'label'     => 'E.3 Evidence File',
@@ -298,18 +299,18 @@ class EffectCrudController extends CrudController
                         'name'    => 'urls',
                         'type'    => 'url',
                         'label'   => 'E.4 Evidence url Source',
-                       
+
                     ],
-                    
+
                 ],
-            
+
                 // optional
                 'new_item_label'  => 'Add Evidence', // customize the text of the button
-              
-                ]   
-            ]);
-            
-            CRUD::addFields([ 
+
+            ]
+        ]);
+
+        CRUD::addFields([
 
             [   // repeatable beneficiaries
                 'name'  => 'beneficiaries_repeat',
@@ -327,23 +328,23 @@ class EffectCrudController extends CrudController
                         'type' => "select_from_array",
                         'label' => 'B.1 Beneficiary type',
                         // 'allows_null' => true,
-                      
+
                         // optional - force the related options to be a custom query, instead of all();
-                        'options'   => $this->getBeneficieryTypes(),     
-                      
+                        'options'   => $this->getBeneficieryTypes(),
+
                     ],
                     [
                         'name'    => 'description',
                         'type'    => 'textarea',
                         'label'   => 'B.2 Benficiaries description',
-                       
-                    ],                
-                    
+
+                    ],
+
                 ],
-            
+
                 // optional
                 'new_item_label'  => 'Add Beneficiary', // customize the text of the button
-                
+
             ],
             [   // CustomHTML
                 'name'  => 'separator_action',
@@ -356,16 +357,16 @@ class EffectCrudController extends CrudController
                 'value' => '<h6><b>About the Action that generates the reported effect.</b></h6>
                 <p>In the next section you will describe the action in more detail: the objective, the affected agents, and details about its scope
 
-                This will allow us to build a landscape of the actions and those affected. This picture will be overlaid on the project Logframe and the frameworks that describe Climate Smart Agriculture. 
+                This will allow us to build a landscape of the actions and those affected. This picture will be overlaid on the project Logframe and the frameworks that describe Climate Smart Agriculture.
                 Please be detailed in the description of objectives, effects and agents affected. The information you provide will be useful only if there is evidence that backs it up.</p>
                 <p>In the box below you can select an action that you have already escribed. If you want to describe a new action, please click on "+ Other"</p>
-               
+
                 <p>In this section you need to choose one of the following options</p>
                 <ol type="1">
                     <li>If the action that is associated to the effect reported has already been described, choose it from the box below. </li>
                     <li>If the action has not yet been described click on the “+ Other” button and describe it.</li>
                 </ol>
-                <p>Remember that you can also edit the description of an action by going to the Action menu item on the left column and then click on “Edit” for the chosen action.</p> 
+                <p>Remember that you can also edit the description of an action by going to the Action menu item on the left column and then click on “Edit” for the chosen action.</p>
                  '
             ],
             [
@@ -373,20 +374,19 @@ class EffectCrudController extends CrudController
                 'name' => 'actions',
                 'ajax' => true,
                 'minimum_input_length' => 0,
-                'inline_create' => [ 
+                'inline_create' => [
                     'entity' => 'action',
-                    'modal_class' => 'modal-dialog modal-xl', 
-                    ],
+                    'modal_class' => 'modal-dialog modal-xl',
+                ],
                 'placeholder' => "Select an Action",
                 'label' =>'',
             ]
         ]);
-      
     }
 
     /**
      * Define what happens when the Update operation is loaded.
-     * 
+     *
      * @see https://backpackforlaravel.com/docs/crud-operation-update
      * @return void
      */
@@ -408,27 +408,27 @@ class EffectCrudController extends CrudController
 
     public function getBeneficieryTypes()
     {
-        return BeneficiaryType::get()->pluck('name','id');
+        return BeneficiaryType::get()->pluck('name', 'id');
     }
 
     public function getIndicators()
     {
-       return Indicator::get()->pluck('name','id');
+        return Indicator::get()->pluck('name', 'id');
     }
 
     public function getLevelAttributions()
     {
-       return LevelAttribution::get()->pluck('name','id');
+        return LevelAttribution::get()->pluck('name', 'id');
     }
-    
+
     public function getIndicatorStatus()
     {
-       return IndicatorStatus::get()->pluck('name','id');
+        return IndicatorStatus::get()->pluck('name', 'id');
     }
 
     public function getDisaggregations()
     {
-       return Disaggregation::get()->pluck('name','id');
+        return Disaggregation::get()->pluck('name', 'id');
     }
 
     public function store(EffectRequest $request)
@@ -438,11 +438,11 @@ class EffectCrudController extends CrudController
 
         $response = $this->traitStore();
         $effect = $this->crud->getCurrentEntry();
-        
+
         $this->updateOrCreateIndicators($request->indicator_repeat, $effect->id);
         $this->updateOrCreateEvidences($request->evidences_repeat, $effect->id);
         $this->updateOrCreateBeneficiaries($request->beneficiaries_repeat, $effect->id);
- 
+
         // do something after save
         return $response;
     }
@@ -453,21 +453,20 @@ class EffectCrudController extends CrudController
 
         $response = $this->traitUpdate();
         $effect = $this->crud->getCurrentEntry();
-        
+
         $this->updateOrCreateIndicators($request->indicator_repeat, $effect->id);
         $this->updateOrCreateEvidences($request->evidences_repeat, $effect->id);
         $this->updateOrCreateBeneficiaries($request->beneficiaries_repeat, $effect->id);
 
-         // do something after save
+        // do something after save
         return $response;
     }
 
     public function updateOrCreateIndicators($repeat, $effect_id)
     {
-
         $indicators_repeat = json_decode($repeat);
 
-        foreach($indicators_repeat as $indicator ){
+        foreach ($indicators_repeat as $indicator) {
             $effect_indicator = LinkEffectIndicator::updateOrCreate(
                 [
                     'id'=> $indicator->effect_indicator_id,
@@ -483,63 +482,59 @@ class EffectCrudController extends CrudController
 
             $effect_indicator->save();
             $dis_name = "disaggregation_id[]";
-            
-           
+
+
             $indicator_value = IndicatorValue::updateOrCreate(
                 [
                     'id'=> $indicator->ind_value_id,
                 ],
                 [
-                'link_effect_indicator_id' => $effect_indicator->id,
-                'value_qualitative' => $indicator->value_qualitative,
-                'value_quantitative' => $indicator->value_quantitative,
-                'url_source' => $indicator->ind_url_source,
-                'file_source' => $indicator->file_source,
-                'disaggregation_id'=> $indicator->$dis_name
+                    'link_effect_indicator_id' => $effect_indicator->id,
+                    'value_qualitative' => $indicator->value_qualitative,
+                    'value_quantitative' => $indicator->value_quantitative,
+                    'url_source' => $indicator->ind_url_source,
+                    'file_source' => $indicator->file_source,
+                    'disaggregation_id'=> $indicator->$dis_name
                 ]
             );
 
             $indicator_value->save();
         }
-        
     }
 
     public function updateOrCreateBeneficiaries($repeat, $effect_id)
     {
         $beneficiaries_repeat = json_decode($repeat);
-    
-        foreach($beneficiaries_repeat as $beneficiary ){
-        //problem with file
-            if(!empty($beneficiary->description)){
+
+        foreach ($beneficiaries_repeat as $beneficiary) {
+            //problem with file
+            if (!empty($beneficiary->description)) {
                 $new_beneficiary  = Beneficiary::updateOrCreate(
                     [
-                    'id' => $beneficiary->id
+                        'id' => $beneficiary->id
                     ],
                     [
-                    'effect_id' =>  $effect_id,
-                    'description' => $beneficiary->description,
-                    'beneficiary_type_id' => $beneficiary->beneficiary_type_id,
+                        'effect_id' =>  $effect_id,
+                        'description' => $beneficiary->description,
+                        'beneficiary_type_id' => $beneficiary->beneficiary_type_id,
                     ]
-                
                 );
-        
+
                 $new_beneficiary->save();
             }
-            
         }
     }
 
     public function updateOrCreateEvidences($repeat, $effect_id)
     {
         $evidence_repeat = json_decode($repeat);
-    
-        foreach($evidence_repeat as $evidence ){
-        //problem with file
-            if(!empty($evidence->description)){
-               
+
+        foreach ($evidence_repeat as $evidence) {
+            //problem with file
+            if (!empty($evidence->description)) {
                 $new_evidence  = Evidence::updateOrCreate(
                     [
-                    'id' => $evidence->id
+                        'id' => $evidence->id
                     ],
                     [
                         'effect_id' =>  $effect_id,
@@ -548,13 +543,10 @@ class EffectCrudController extends CrudController
                         'urls' => $evidence->urls,
                         'files_description' => $evidence->files_description
                     ]
-                
                 );
-        
+
                 $new_evidence->save();
             }
-            
         }
     }
-    
 }

--- a/app/Models/Effect.php
+++ b/app/Models/Effect.php
@@ -33,8 +33,7 @@ class Effect extends Model
     */
     public function getIndicatorRepeatAttribute()
     {
-        $effects_indicators =  $this->link_effects_indicators->map(function ($effect_indicator, $key){
-
+        $effects_indicators =  $this->link_effects_indicators->map(function ($effect_indicator, $key) {
             return [
                 'effect_indicator_id'=>$effect_indicator['id'],
                 'indicators'=>$effect_indicator['indicator_id'],
@@ -42,30 +41,25 @@ class Effect extends Model
                 'baseline_qualitative'=>$effect_indicator['baseline_qualitative'],
                 'baseline_quantitative'=>$effect_indicator['baseline_quantitative'],
             ];
-   
         });
 
         $indicators_edit = [];
-        foreach($effects_indicators as $effect_indicator){
+        foreach ($effects_indicators as $effect_indicator) {
+            $indicator_values = IndicatorValue::where('link_effect_indicator_id', '=', $effect_indicator['effect_indicator_id'])->get();
 
-        $indicator_values = IndicatorValue::where('link_effect_indicator_id', '=', $effect_indicator['effect_indicator_id'])->get();
-
-            foreach($indicator_values as $indi_value){
-        
+            foreach ($indicator_values as $indi_value) {
                 $effect_indicator['ind_value_id'] = $indi_value['id'];
                 $effect_indicator['value_quantitative'] = $indi_value['value_quantitative'];
                 $effect_indicator['value_qualitative'] = $indi_value['value_qualitative'];
                 $effect_indicator['ind_url_source'] = $indi_value['url_source'];
                 $effect_indicator['disaggregation_id[]'] = $indi_value['disaggregation_id'];
                 // $effect_indicator['file_source'] = $indi_value['file_source'];
-    
             }
             $indicators_edit[]= $effect_indicator;
-
         }
-     
-      
-        return  $indicators_edit;        
+
+
+        return  $indicators_edit;
     }
 
     public function getBeneficiariesRepeatAttribute()
@@ -73,15 +67,18 @@ class Effect extends Model
         return $this->beneficiaries->map(function ($beneficiary, $key) {
             return ['id'=>$beneficiary['id'],'beneficiary_type_id'=>$beneficiary['beneficiary_type_id'],'description'=>$beneficiary['description']];
         });
-        
     }
-    
+
     public function getEvidencesRepeatAttribute()
     {
         return $this->evidences->map(function ($evid, $key) {
-            return ['id'=>$evid['id'],'description'=>$evid['description'],'files_description'=>$evid['files_description'], 'files'=>$evid['files'], 'urls'=>$evid['urls']];
+            return [
+                'id'=>$evid['id'],
+                'description'=>$evid['description'],
+                'files_description'=>$evid['files_description'],
+                'evidence_files'=>$evid['files'],
+                'urls'=>$evid['urls']];
         });
-        
     }
 
     /*
@@ -96,7 +93,7 @@ class Effect extends Model
 
     public function indicators()
     {
-        return $this->belongsToMany(Indicator::class, '_link_effects_indicators','effect_id', 'indicator_id')->withPivot('level_attribution_id')->withTimestamps();
+        return $this->belongsToMany(Indicator::class, '_link_effects_indicators', 'effect_id', 'indicator_id')->withPivot('level_attribution_id')->withTimestamps();
     }
 
     public function evidences()
@@ -137,5 +134,4 @@ class Effect extends Model
     | MUTATORS
     |--------------------------------------------------------------------------
     */
-
 }

--- a/app/Models/Evidence.php
+++ b/app/Models/Evidence.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Models\Traits\HasUploadFields;
 use Backpack\CRUD\app\Models\Traits\CrudTrait;
 use Illuminate\Database\Eloquent\Model;
 
 class Evidence extends Model
 {
-    use CrudTrait;
+    use CrudTrait, HasUploadFields;
 
     /*
     |--------------------------------------------------------------------------
@@ -22,7 +23,7 @@ class Evidence extends Model
     // protected $fillable = [];
     // protected $hidden = [];
     // protected $dates = [];
-    protected $casts = ['file' => 'array'];
+    protected $casts = ['files' => 'array'];
 
     /*
     |--------------------------------------------------------------------------
@@ -57,4 +58,12 @@ class Evidence extends Model
     | MUTATORS
     |--------------------------------------------------------------------------
     */
+    public function setFilesAttribute($value)
+    {
+        $attribute_name = "files";
+        $disk = "public";
+        $destination_path = "evidence";
+
+        $this->uploadMultipleFilesToDiskFromRepeatable($value, $attribute_name, $disk, $destination_path);
+    }
 }

--- a/app/Models/Traits/HasUploadFields.php
+++ b/app/Models/Traits/HasUploadFields.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Models\Traits;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Storage;
+
+/*
+|--------------------------------------------------------------------------
+| Methods for storing uploaded files (used in CRUD).
+|--------------------------------------------------------------------------
+*/
+trait HasUploadFields
+{
+    /**
+     * Handle file upload and DB storage for a file:
+     * - on CREATE
+     *     - stores the file at the destination path
+     *     - generates a name
+     *     - stores the full path in the DB;
+     * - on UPDATE
+     *     - if the value is null, deletes the file and sets null in the DB
+     *     - if the value is different, stores the different file and updates DB value.
+     *
+     * @param string $value            Value for that column sent from the input.
+     * @param string $attribute_name   Model attribute name (and column in the db).
+     * @param string $disk             Filesystem disk used to store files.
+    * @param string $destination_path Path in disk where to store the files.
+     */
+    public function uploadFileToDiskFromRepeatable($value, $attribute_name, $disk, $destination_path)
+    {
+        $destination_path .= "/".time();
+
+        $request = Request::instance();
+
+        // if a new file is uploaded, delete the file from the disk
+        if ($request->hasFile($attribute_name) &&
+            $this->{$attribute_name} &&
+            $this->{$attribute_name} != null) {
+            Storage::disk($disk)->delete($this->{$attribute_name});
+            $this->attributes[$attribute_name] = null;
+        }
+
+        // if the file input is empty, delete the file from the disk
+        if (is_null($value) && $this->{$attribute_name} != null) {
+            Storage::disk($disk)->delete($this->{$attribute_name});
+            $this->attributes[$attribute_name] = null;
+        }
+        // if a new file is uploaded, store it on disk and its filename in the database
+        // use the given value to select which of the file uploads to take...
+        if ($request->hasFile($value) && $request->file($value)->isValid()) {
+            // 1. Generate a new file name
+            $file = $request->file($value);
+            //$new_file_name = md5($file->getClientOriginalName().time()).'.'.$file->getClientOriginalExtension();
+            $new_file_name = $file->getClientOriginalName();
+
+            // 2. Move the new file to the correct path
+            $file_path = $file->storeAs($destination_path, $new_file_name, $disk);
+
+            // 3. Save the complete path to the database
+            $this->attributes[$attribute_name] = $file_path;
+        }
+    }
+
+    /**
+     * Handle multiple file upload and DB storage:
+     * - if files are sent
+     *     - stores the files at the destination path
+     *     - generates random names
+     *     - stores the full path in the DB, as JSON array;
+     * - if a hidden input is sent to clear one or more files
+     *     - deletes the file
+     *     - removes that file from the DB.
+     *
+     * @param string $value            Value for that column sent from the input.
+     * @param string $attribute_name   Model attribute name (and column in the db).
+     * @param string $disk             Filesystem disk used to store files.
+     * @param string $destination_path Path in disk where to store the files.
+     */
+    public function uploadMultipleFilesToDiskFromRepeatable($value, $attribute_name, $disk, $destination_path)
+    {
+        $destination_path .= "/".time();
+
+        $request = Request::instance();
+        if (! is_array($this->{$attribute_name})) {
+            $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
+        } else {
+            $attribute_value = $this->{$attribute_name};
+        }
+        $files_to_clear = $request->get('clear_'.$value);
+
+        // if a file has been marked for removal,
+        // delete it from the disk and from the db
+        if ($files_to_clear) {
+            foreach ($files_to_clear as $key => $filename) {
+                Storage::disk($disk)->delete($filename);
+                $attribute_value = Arr::where($attribute_value, function ($value, $key) use ($filename) {
+                    return $value != $filename;
+                });
+            }
+        }
+
+        // if a new file is uploaded, store it on disk and its filename in the database
+        // use the $value as the index to determine which of the file uploads to get
+        if ($request->hasFile($value)) {
+            foreach ($request->file($value) as $file) {
+                if ($file->isValid()) {
+
+                    // 1. Move the new file to the correct path with the original name
+                    $file_path = $file->storeAs($destination_path, $file->getClientOriginalName(), $disk);
+
+                    // 2. Add the public path to the database
+                    $attribute_value[] = $file_path;
+                }
+            }
+        }
+
+        $this->attributes[$attribute_name] = json_encode($attribute_value);
+    }
+
+    public function uploadFileToDiskWithOriginalName($value, $attribute_name, $disk, $destination_path)
+    {
+        $destination_path .= "/".time();
+
+        $request = Request::instance();
+
+        // if a new file is uploaded, delete the file from the disk
+        if ($request->hasFile($attribute_name) &&
+            $this->{$attribute_name} &&
+            $this->{$attribute_name} != null) {
+            Storage::disk($disk)->delete($this->{$attribute_name});
+            $this->attributes[$attribute_name] = null;
+        }
+
+        // if the file input is empty, delete the file from the disk
+        if (is_null($value) && $this->{$attribute_name} != null) {
+            Storage::disk($disk)->delete($this->{$attribute_name});
+            $this->attributes[$attribute_name] = null;
+        }
+        // if a new file is uploaded, store it on disk and its filename in the database
+        if ($request->hasFile($attribute_name) && $request->file($attribute_name)->isValid()) {
+            // 1. Generate a new file name
+            $file = $request->file($attribute_name);
+            //$new_file_name = md5($file->getClientOriginalName().time()).'.'.$file->getClientOriginalExtension();
+            $new_file_name = $file->getClientOriginalName();
+
+            // 2. Move the new file to the correct path
+            $file_path = $file->storeAs($destination_path, $new_file_name, $disk);
+
+            // 3. Save the complete path to the database
+            $this->attributes[$attribute_name] = $file_path;
+        }
+    }
+
+    public function uploadMultipleFilesToDiskWithOriginalName($value, $attribute_name, $disk, $destination_path)
+    {
+        $destination_path .= "/".time();
+
+
+        $request = Request::instance();
+        if (! is_array($this->{$attribute_name})) {
+            $attribute_value = json_decode($this->{$attribute_name}, true) ?? [];
+        } else {
+            $attribute_value = $this->{$attribute_name};
+        }
+        $files_to_clear = $request->get('clear_'.$attribute_name);
+
+        // if a file has been marked for removal,
+        // delete it from the disk and from the db
+        if ($files_to_clear) {
+            foreach ($files_to_clear as $key => $filename) {
+                Storage::disk($disk)->delete($filename);
+                $attribute_value = Arr::where($attribute_value, function ($value, $key) use ($filename) {
+                    return $value != $filename;
+                });
+            }
+        }
+
+        // if a new file is uploaded, store it on disk and its filename in the database
+        if ($request->hasFile($attribute_name)) {
+            foreach ($request->file($attribute_name) as $file) {
+                if ($file->isValid()) {
+
+                    // 1. Move the new file to the correct path with the original name
+                    $file_path = $file->storeAs($destination_path, $file->getClientOriginalName(), $disk);
+
+                    // 2. Add the public path to the database
+                    $attribute_value[] = $file_path;
+                }
+            }
+        }
+
+        $this->attributes[$attribute_name] = json_encode($attribute_value);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2040,6 +2040,11 @@
                 "node-releases": "^1.1.66"
             }
         },
+        "bs-custom-file-input": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz",
+            "integrity": "sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA=="
+        },
         "buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "vue-template-compiler": "^2.6.12"
     },
     "dependencies": {
-        "bootstrap-select": "^1.13.18"
+        "bootstrap-select": "^1.13.18",
+        "bs-custom-file-input": "^1.3.4"
     }
 }

--- a/resources/views/vendor/backpack/crud/fields/repeatable_with_upload.blade.php
+++ b/resources/views/vendor/backpack/crud/fields/repeatable_with_upload.blade.php
@@ -1,0 +1,212 @@
+{{-- REPEATABLE FIELD TYPE --}}
+
+@php
+  $field['value'] = old($field['name']) ? old($field['name']) : (isset($field['value']) ? $field['value'] : (isset($field['default']) ? $field['default'] : '' ));
+  // make sure the value is a JSON string (not array, if it's cast in the model)
+  $field['value'] = is_array($field['value']) ? json_encode($field['value']) : $field['value'];
+@endphp
+
+@include('crud::fields.inc.wrapper_start')
+  <label>{!! $field['label'] !!}</label>
+  @include('crud::fields.inc.translatable_icon')
+  <input
+      type="hidden"
+      name="{{ $field['name'] }}"
+      data-init-function="bpFieldInitRepeatableElement"
+      value="{{ $field['value'] }}"
+      @include('crud::fields.inc.attributes')
+  >
+
+  {{-- HINT --}}
+  @if (isset($field['hint']))
+      <p class="help-block text-muted text-sm">{!! $field['hint'] !!}</p>
+  @endif
+
+
+
+<div class="container-repeatable-elements">
+    <div data-repeatable-holder="{{ $field['name'] }}"></div>
+
+    @push('before_scripts')
+    <div class="col-md-12 well repeatable-element row m-1 p-2" data-repeatable-identifier="{{ $field['name'] }}">
+      @if (isset($field['fields']) && is_array($field['fields']) && count($field['fields']))
+        <button type="button" class="close delete-element"><span aria-hidden="true">×</span></button>
+        @foreach($field['fields'] as $subfield)
+          @php
+              $subfield = $crud->makeSureFieldHasNecessaryAttributes($subfield);
+              $fieldViewNamespace = $subfield['view_namespace'] ?? 'crud::fields';
+              $fieldViewPath = $fieldViewNamespace.'.'.$subfield['type'];
+              $subfield['showAsterisk'] = false;
+          @endphp
+
+          @include($fieldViewPath, ['field' => $subfield])
+        @endforeach
+
+      @endif
+    </div>
+    @endpush
+
+  </div>
+
+
+  <button type="button" class="btn btn-outline-primary btn-sm ml-1 add-repeatable-element-button">+ {{ $field['new_item_label'] ?? trans('backpack::crud.new_item') }}</button>
+
+@include('crud::fields.inc.wrapper_end')
+
+@if ($crud->fieldTypeNotLoaded($field))
+  @php
+      $crud->markFieldTypeAsLoaded($field);
+  @endphp
+  {{-- FIELD EXTRA CSS  --}}
+  {{-- push things in the after_styles section --}}
+
+  @push('crud_fields_styles')
+      <!-- no styles -->
+      <style type="text/css">
+        .repeatable-element {
+          border: 1px solid rgba(0,40,100,.12);
+          border-radius: 5px;
+          background-color: #f0f3f94f;
+        }
+        .container-repeatable-elements .delete-element {
+          z-index: 2;
+          position: absolute!important;
+          margin-left: -24px;
+          margin-top: 0px;
+          height: 30px;
+          width: 30px;
+          border-radius: 15px;
+          text-align: center;
+          background-color: #e8ebf0!important;;
+        }
+      </style>
+  @endpush
+
+  {{-- FIELD EXTRA JS --}}
+  {{-- push things in the after_scripts section --}}
+
+  @push('crud_fields_scripts')
+      <script>
+        /**
+         * Takes all inputs and makes them an object.
+         */
+        function repeatableInputToObj(container_name) {
+            var arr = [];
+            var obj = {};
+
+            var container = $('[data-repeatable-holder='+container_name+']');
+
+            container.find('.well').each(function () {
+                $(this).find('input, select, textarea').each(function () {
+                    if ($(this).data('repeatable-input-name')) {
+                        obj[$(this).data('repeatable-input-name')] = $(this).val();
+                    }
+                });
+                arr.push(obj);
+                obj = {};
+            });
+
+            return arr;
+        }
+
+        /**
+         * The method that initializes the javascript on this field type.
+         */
+        function bpFieldInitRepeatableElement(element) {
+
+            var field_name = element.attr('name');
+
+            // element will be a jQuery wrapped DOM node
+            var container = $('[data-repeatable-identifier='+field_name+']');
+
+            // make sure the inputs no longer have a "name" attribute,
+            // so that the form will not send the inputs as request variables;
+            // use a "data-repeatable-input-name" attribute to store the same information;
+            container.find('input, select, textarea')
+                    .each(function(){
+                        if ($(this).data('name')) {
+                            var name_attr = $(this).data('name');
+                            $(this).removeAttr("data-name");
+                        } else if ($(this).attr('name')) {
+                            var name_attr = $(this).attr('name');
+                            $(this).removeAttr("name");
+                        }
+                        $(this).attr('data-repeatable-input-name', name_attr)
+                    });
+
+            // make a copy of the group of inputs in their default state
+            // this way we have a clean element we can clone when the user
+            // wants to add a new group of inputs
+            var field_group_clone = container.clone();
+            container.remove();
+
+            element.parent().find('.add-repeatable-element-button').click(function(){
+                newRepeatableElement(container, field_group_clone);
+            });
+
+            if (element.val()) {
+                var repeatable_fields_values = JSON.parse(element.val());
+
+                for (var i = 0; i < repeatable_fields_values.length; ++i) {
+                    newRepeatableElement(container, field_group_clone, repeatable_fields_values[i]);
+                }
+            } else {
+                element.parent().find('.add-repeatable-element-button').trigger('click');
+            }
+
+            if (element.closest('.modal-content').length) {
+                element.closest('.modal-content').find('.save-block').click(function(){
+                    element.val(JSON.stringify(repeatableInputToObj(field_name)));
+                })
+            } else if (element.closest('form').length) {
+                element.closest('form').submit(function(){
+                    element.val(JSON.stringify(repeatableInputToObj(field_name)));
+                    return true;
+                })
+            }
+        }
+
+        /**
+         * Adds a new field group to the repeatable input.
+         */
+        function newRepeatableElement(container, field_group, values) {
+
+            var field_name = container.data('repeatable-identifier');
+            var new_field_group = field_group.clone();
+
+            //this is the container for this repeatable group that holds it inside the main form.
+            var container_holder = $('[data-repeatable-holder='+field_name+']');
+
+            new_field_group.find('.delete-element').click(function(){
+                new_field_group.find('input, select, textarea').each(function(i, el) {
+                    //we trigger this event so fields can intercept when they are beeing deleted from the page
+                    //implemented because of ckeditor instances that stayed around when deleted from page
+                    //introducing unwanted js errors and high memory usage.
+                    $(el).trigger('backpack_field.deleted');
+                });
+                $(this).parent().remove();
+            });
+
+            if (values != null) {
+                // set the value on field inputs, based on the JSON in the hidden input
+                new_field_group.find('input, select, textarea').each(function () {
+                    if ($(this).data('repeatable-input-name')) {
+                        $(this).val(values[$(this).data('repeatable-input-name')]);
+
+                        // if it's a Select input with no options, also attach the values as a data attribute;
+                        // this is done because the above val() call will do nothing if the options aren't there
+                        // so the fields themselves have to treat this use case, and look at data-selected-options
+                        // and create the options based on those values
+                        if ($(this).is('select') && $(this).children('option').length == 0) {
+                          $(this).attr('data-selected-options', JSON.stringify(values[$(this).data('repeatable-input-name')]));
+                        }
+                    }
+                });
+            }
+            //we push the fields to the correct container in page.
+            container_holder.append(new_field_group);
+            initializeFieldsWithJavascript(container_holder);
+        }
+    </script>
+  @endpush
+@endif

--- a/resources/views/vendor/backpack/crud/fields/upload_multiple_for_repeatable.blade.php
+++ b/resources/views/vendor/backpack/crud/fields/upload_multiple_for_repeatable.blade.php
@@ -38,9 +38,11 @@
     	@endforeach
     </div>
     @endif
+    @else
+    <div class="well well-sm existing-file"></div>
     @endif
 	{{-- Show the file picker on CREATE form. --}}
-	<input name="{{ $field['name'] }}[]" type="hidden" value="">
+	<input name="{{ $field['name'] }}[]" type="hidden" data-for-type="file">
 	<div class="backstrap-file mt-2">
 		<input
 	        type="file"
@@ -71,21 +73,45 @@
         <script>
         	function bpFieldInitUploadMultipleElement(element) {
         		var fieldName = element.attr('data-field-name');
-        		var clearFileButton = element.find(".file-clear-button");
         		var fileInput = element.find("input[type=file]");
         		var inputLabel = element.find("label.backstrap-file-label");
 
+                var fileHidden = element.find("input[type=hidden]")
+                var filePreview = element.find(".existing-file")
+
+
+                if($(fileHidden).data('initial') && $(fileHidden).data('initial').length > 0) {
+                    //get initial file values from data passed by the repeatable field:
+                    for(i=0; i<$(fileHidden).data('initial').length; ++i) {
+                        var path = $(fileHidden).data('initial')[i]
+                        var filename = path.split('/')[path.split('/').length - 1]
+                        var repeatIndex = $(fileHidden).data('index')
+
+                        filePreview.append(`<div class="file-preview border border-light">
+                            <a target="_blank" href="{{ url('') }}/${path}">${filename}</a>
+                            <a href="#" class="btn btn-light btn-sm float-right file-clear-button" title="Clear file" data-filename="${path}" data-index="${repeatIndex}"><i class="la la-remove"></i></a>
+                            <div class="clearfix"></div>
+                        </div>`)
+
+                    }
+                } else {
+                    filePreview.remove()
+                }
+
+        		var clearFileButton = element.find(".file-clear-button");
 		        clearFileButton.click(function(e) {
 		        	e.preventDefault();
 		        	var container = $(this).parent().parent();
 		        	var parent = $(this).parent();
+                    var repeatIndex = $(this).data('index');
+
 		        	// remove the filename and button
 		        	parent.remove();
 		        	// if the file container is empty, remove it
 		        	if ($.trim(container.html())=='') {
 		        		container.remove();
 		        	}
-		        	$("<input type='hidden' name='clear_"+fieldName+"[]' value='"+$(this).data('filename')+"'>").insertAfter(fileInput);
+		        	$("<input type='hidden' name='clear_"+fieldName+"_"+repeatIndex+"[]' value='"+$(this).data('filename')+"'>").insertAfter(fileInput);
 		        });
 
 		        fileInput.change(function() {
@@ -93,6 +119,8 @@
 		        	// remove the hidden input, so that the setXAttribute method is no longer triggered
 		        	$(this).next("input[type=hidden]").remove();
 		        });
+
+
         	}
         </script>
     @endpush

--- a/resources/views/vendor/backpack/crud/fields/upload_multiple_for_repeatable.blade.php
+++ b/resources/views/vendor/backpack/crud/fields/upload_multiple_for_repeatable.blade.php
@@ -1,0 +1,99 @@
+@php
+    if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-init-function'])){
+        $field['wrapperAttributes']['data-init-function'] = 'bpFieldInitUploadMultipleElement';
+    }
+
+    if (!isset($field['wrapperAttributes']) || !isset($field['wrapperAttributes']['data-field-name'])) {
+        $field['wrapperAttributes']['data-field-name'] = $field['name'];
+    }
+
+@endphp
+
+<!-- upload multiple input -->
+@include('crud::fields.inc.wrapper_start')
+    <label>{!! $field['label'] !!}</label>
+    @include('crud::fields.inc.translatable_icon')
+
+	{{-- Show the file name and a "Clear" button on EDIT form. --}}
+	@if (isset($field['value']))
+	@php
+		if (is_string($field['value'])) {
+			$values = json_decode($field['value'], true) ?? [];
+		} else {
+			$values = $field['value'];
+		}
+	@endphp
+	@if (count($values))
+    <div class="well well-sm existing-file">
+    	@foreach($values as $key => $file_path)
+    		<div class="file-preview">
+    			@if (isset($field['temporary']))
+		            <a target="_blank" href="{{ isset($field['disk'])?asset(\Storage::disk($field['disk'])->temporaryUrl($file_path, Carbon\Carbon::now()->addMinutes($field['temporary']))):asset($file_path) }}">{{ $file_path }}</a>
+		        @else
+		            <a target="_blank" href="{{ isset($field['disk'])?asset(\Storage::disk($field['disk'])->url($file_path)):asset($file_path) }}">{{ $file_path }}</a>
+		        @endif
+            <a href="#" class="btn btn-light btn-sm float-right file-clear-button" title="Clear file" data-filename="{{ $file_path }}"><i class="la la-remove"></i></a>
+		    	<div class="clearfix"></div>
+	    	</div>
+    	@endforeach
+    </div>
+    @endif
+    @endif
+	{{-- Show the file picker on CREATE form. --}}
+	<input name="{{ $field['name'] }}[]" type="hidden" value="">
+	<div class="backstrap-file mt-2">
+		<input
+	        type="file"
+	        name="{{ $field['name'] }}[]"
+	        value="@if (old(square_brackets_to_dots($field['name']))) old(square_brackets_to_dots($field['name'])) @elseif (isset($field['default'])) $field['default'] @endif"
+	        @include('crud::fields.inc.attributes', ['default_class' =>  isset($field['value']) && $field['value']!=null?'file_input backstrap-file-input':'file_input backstrap-file-input'])
+	        multiple
+	    >
+        <label class="backstrap-file-label" for="customFile"></label>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+@include('crud::fields.inc.wrapper_end')
+
+{{-- ########################################## --}}
+{{-- Extra CSS and JS for this particular field --}}
+{{-- If a field type is shown multiple times on a form, the CSS and JS will only be loaded once --}}
+@if ($crud->fieldTypeNotLoaded($field))
+    @php
+        $crud->markFieldTypeAsLoaded($field);
+    @endphp
+
+    @push('crud_fields_scripts')
+        <!-- no scripts -->
+        <script>
+        	function bpFieldInitUploadMultipleElement(element) {
+        		var fieldName = element.attr('data-field-name');
+        		var clearFileButton = element.find(".file-clear-button");
+        		var fileInput = element.find("input[type=file]");
+        		var inputLabel = element.find("label.backstrap-file-label");
+
+		        clearFileButton.click(function(e) {
+		        	e.preventDefault();
+		        	var container = $(this).parent().parent();
+		        	var parent = $(this).parent();
+		        	// remove the filename and button
+		        	parent.remove();
+		        	// if the file container is empty, remove it
+		        	if ($.trim(container.html())=='') {
+		        		container.remove();
+		        	}
+		        	$("<input type='hidden' name='clear_"+fieldName+"[]' value='"+$(this).data('filename')+"'>").insertAfter(fileInput);
+		        });
+
+		        fileInput.change(function() {
+	                inputLabel.html("Files selected. After save, they will show up above.");
+		        	// remove the hidden input, so that the setXAttribute method is no longer triggered
+		        	$(this).next("input[type=hidden]").remove();
+		        });
+        	}
+        </script>
+    @endpush
+@endif


### PR DESCRIPTION
## Overview
This enables file uploads within a repeatable field using 2 new custom fields. The example used to test is adding files to the evidence model via the `evidences_repeat` repeating field in the Effects Crud Controller.

## To use
1. It's only enabled for "upload_multiple" - single file uploads won't work (we could probably get them working too, but it would take longer and hopefully we can just use upload multiples instead?)
2. There must be a field with `'upload' = true` that is *not* inside a repeatable field. Otherwise the form will not be sent using the right enctype and no files will be uploaded. In the EffectCrudController I got around this by adding a `dummy_upload` hidden field. 
3. The actual files are added to the request directly, so each file upload must have a unique name (and a way to match the right file to the right repeat). I setup the upload field to append the index of the repeat-group to the field-name. So file uploads for the evidence_files will be `evidence_files_0[]`, `evidence_files_1[]` etc.  This custom name needs to be passed to the server as the $value of the attribute - see the example in the updateOrCreate() for the evidence.

4. The model needs to use the custom `hasUploadFields` trait (inside `App\Models\Traits\`). It also needs a mutator for the attribute, that calls the `uploadMultipleFilesToDiskFromRepeatable()` method. 

## New Fields -
### Repeatable with upload
 - The custom repeat field checks each subfield and doesn't remove the 'name' attribute from file inputs. This enables the file input to actually function and send the file along with the request.
 - On rendering a repeat with existing data, it checks for upload fields and adds custom data-* attributes to pass the file data into the field via JS.

### Upload multiple for repeatable
 - The main difference from the standard upload_multiple is that the file previews are rendered on the client-side, based on the custom data-* attributes passed onto the hidden input variable by the repeatable field. 
 - This field should *only* be used inside a `repeatable_with_upload` field!

